### PR TITLE
Control file improvements

### DIFF
--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -30,9 +30,9 @@
 	<key>ModuleSize</key>
 	<dict>
 		<key>columns</key>
-		<string>4</string>
+		<string>1</string>
 		<key>rows</key>
-		<string>2</string>
+		<string>1</string>
 	</dict>
 	<key>CFBundleSupportedPlatforms</key>
 	<array>

--- a/control
+++ b/control
@@ -5,5 +5,5 @@ Architecture: iphoneos-arm
 Description: A Safemode toggle for your Control Center. Requires Silo
 Author: M4cs
 Section: Control Center (Modules)
-Maintainer: M4cs
+Maintainer: M4cs <macs@m4cs.xyz>
 Depends: firmware (>= 11.0), com.ioscreatix.silo

--- a/control
+++ b/control
@@ -1,6 +1,6 @@
 Package: com.ezccmodules.control-center.ezsafemodemodule
 Name: EzSafemode
-Version: 0.0.1
+Version: 0.0.2
 Architecture: iphoneos-arm
 Description: A Safemode toggle for your Control Center. Requires Silo
 Author: M4cs

--- a/control
+++ b/control
@@ -6,3 +6,4 @@ Description: A Safemode toggle for your Control Center. Requires Silo
 Author: M4cs
 Section: Control Center (Modules)
 Maintainer: M4cs
+Depends: firmware (>= 11.0), com.ioscreatix.silo


### PR DESCRIPTION
This will ensure that people 

1. Are at least on Firmware 11.0 or higher as Silo and these modules are not made for lower anyway.

2. Have Silo installed or have Cydia queue it for installation and if they do not have the creatix repo added they'll be presented with an error and a block on installing the module

As for the email at maintainer field, that's just a thing that's common good practice for dpkg control files, more info here: https://www.debian.org/doc/manuals/maint-guide/dreq.en.html